### PR TITLE
Manage pyqt4 api version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,67 @@
+# Python files
+*.py[cod]
+
+# C extensions
+*.so
+*.dll
+*.dylib
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+
+# Compiled Object files
+*.os
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+build-scons
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+__pycache__
+*.pth
+
+# Installer logs
+pip-log.txt
+.amlog
+.sconsign.dblite
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Designer files
+*visualea/src/visualea/ui_*
+
+# Translations
+*.mo
+
+# Vim files
+*.swp
+*.*~
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+.settings
+.idea
+
+# svn
+.svn
+
+# temporary files
+*._icon.png
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+travis.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,55 @@
+platform:
+  - x86
+  - x64
+
+environment:
+  matrix:
+    - CONDA_RECIPE: conda
+      CONDA_VERSION: 2
+    - CONDA_RECIPE: conda
+      CONDA_VERSION: 3
+
+# matrix:
+#   allow_failures:
+#     - platform: x86
+#       CONDA_RECIPE: conda
+#       CONDA_VERSION: 3
+#     - platform: x64
+#       CONDA_RECIPE: conda
+#       CONDA_VERSION: 3
+
+install:
+  - git clone https://github.com/OpenAlea/appveyor-ci.git
+  - cd appveyor-ci
+  - call install.bat
+
+before_build:
+  - call before_build.bat
+
+build_script:
+  - call build_script.bat
+
+after_build:
+  - call after_build.bat
+
+deploy:
+  provider: Script
+
+before_deploy:
+  - call before_deploy.bat
+
+deploy_script:
+  - call deploy_script.bat
+
+after_deploy:
+  - call after_deploy.bat
+
+on_success:
+  - call on_success.bat
+
+on_failure:
+  - call on_failure.bat
+
+on_finish:
+  - call on_finish.bat
+

--- a/src/openalea/vpltk/qt/__init__.py
+++ b/src/openalea/vpltk/qt/__init__.py
@@ -15,6 +15,10 @@
 # Contributor: Colin Duquesnoy
 # Website: http://github.com/pyqode/pyqode.qt
 #
+# Copyright © 2018 INRIA - CIRAD
+# Contributor: Christophe Pradal
+# http://github.com/openalea/vpltk
+#
 # -------------------------------------------
 # Licensed under the terms of the MIT License
 # -------------------------------------------
@@ -24,21 +28,16 @@ import os
 import sys
 import logging
 
-__version__ = '2.6.0.dev0'
-__version_info__ = None
+__version__ = '2.10.0'
 is_pyqt46 = False
-
-PyQt_license_warning = "your application or derivative works must be released under GPL or CeCILL license !"
 
 #: Qt API environment variable name
 QT_API = 'QT_API'
 #: names of the expected PyQt5 api
 PYQT5_API = ['pyqt5']
 #: names of the expected PyQt4 api
-PYQT4_API = [
-    'pyqt',  # name used in IPython.qt
-    'pyqt4'  # pyqode.qt original name
-]
+PYQT4_API = ['pyqt']  # name used in IPython.qt
+
 #: names of the expected PySide api
 PYSIDE_API = ['pyside']
 
@@ -46,13 +45,13 @@ QT_MODULE_NAME = None
 
 # If IPython is installed, use its order to avoid multiple python-qt loads
 try:
-    from IPython.external.qt import api_opts
+    from qtconsole.qt import api_opts
 except ImportError:
     import openalea.vpltk.qt.qt_loaders
-    QT_API_ORDER = ['pyside', 'pyqt', 'pyqt5']
+    QT_API_ORDER = ['pyqt', 'pyside', 'pyqt5']
 else:
     QT_API_ORDER = api_opts
-_api_version = int(os.environ.setdefault('QT_API_VERSION', '0'))
+_api_version = int(os.environ.setdefault('QT_API_VERSION', '2'))
 
 
 def setup_apiv2():
@@ -61,26 +60,16 @@ def setup_apiv2():
     """
     # setup PyQt api to version 2
     if sys.version_info[0] == 2:
+        logging.getLogger(__name__).debug(
+            'setting up SIP API to version 2')
         import sip
-        if _api_version:
-            default = _api_version
-            apis = [
-                ("QDate", default),
-                ("QDateTime", default),
-                ("QString", default),
-                ("QTextStream", default),
-                ("QTime", default),
-                ("QUrl", default),
-                ("QVariant", default),
-                ("QFileDialog", default),
-            ]
-            for name, version in apis:
-                try:
-                    sip.setapi(name, version)
-                except ValueError:
-                    logging.getLogger(__name__).critical("failed to set up sip api to version 2 for PyQt4")
-                    raise ImportError('PyQt4')
-        from PyQt4.QtCore import PYQT_VERSION_STR as __version__
+        try:
+            sip.setapi("QString", 2)
+            sip.setapi("QVariant", 2)
+        except ValueError:
+            logging.getLogger(__name__).critical(
+                "failed to set up sip api to version 2 for PyQt4")
+            raise ImportError('PyQt4')
 
 
 def load_pyside():

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,45 @@
+language: cpp
+
+os:
+  - linux
+  - osx
+
+sudo: required
+
+services:
+  - docker
+
+env:
+ - CONDA_RECIPE=conda
+   CONDA_VERSION=2
+
+install:
+  - git clone https://github.com/OpenAlea/travis-ci.git
+  - cd travis-ci
+  - source install.sh
+
+before_script:
+  - source before_script.sh
+
+script:
+  - source script.sh
+
+after_success:
+  - source after_success.sh
+
+after_failure:
+  - source after_failure.sh
+
+before_deploy:
+  - source before_deploy.sh
+
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: bash deploy_script.sh
+
+after_deploy:
+  - source after_deploy.sh
+
+after_script:
+  - source after_script.sh


### PR DESCRIPTION
Fix issue #3 
Use v2 by default and update the code to set the correct PyQt api.
This is a first version. More work is needed to simplify the code and reuse maintain code.