### PR TITLE
Fix error when trying to detect Qt interface (PySide, PyQt4, PyQt5)

### DIFF
--- a/src/openalea/vpltk/qt/__init__.py
+++ b/src/openalea/vpltk/qt/__init__.py
@@ -127,12 +127,13 @@ def autodetect():
     """
     logging.getLogger(__name__).debug('auto-detecting QT_API')
     for API in QT_API_ORDER:
-        try:
-            QT_API_LOADER[API]()
-        except ImportError:
-            continue
-        else:
-            break
+        if API in QT_API_LOADER:
+            try:
+                QT_API_LOADER[API]()
+            except ImportError:
+                continue
+            else:
+                break
 
 
 if QT_API in os.environ:


### PR DESCRIPTION
This is just an hack. 
We need to update the code of vpltk/qt/__init__.py to synchronised it with qtconsole (or depends completly on it).